### PR TITLE
Extend for cloud-storage-writing

### DIFF
--- a/api/history.py
+++ b/api/history.py
@@ -40,13 +40,13 @@ class Walker:
             end = time.time()
             diff = end - start
             m_diff = int(diff / 60)
+            i += 1
             remaining_versions = (len(versions) - i)
             m_projected = m_diff * remaining_versions
             h_projected = int(m_projected/ 60)
             m_projected_rem = int(m_projected % 60)
             now = datetime.datetime.now()
             projected_end = now + datetime.timedelta(minutes = m_projected)
-            i += 1
             print "### Execution for version %s took %s minutes. ###" % (version, m_diff)
             if remaining_versions > 0:
                print "### Still have %s versions to go, that will be %s hours and %s minutes. Projected end is %s. ###"\

--- a/hopper.py
+++ b/hopper.py
@@ -2,7 +2,7 @@ import argparse
 
 from impl import MvnGit
 from impl import ResultParser
-from impl.FileDumper import FileDumper
+from impl.FileDumper import FileDumper, CloudDumper
 from impl.GradleCommitWalker import GradleJMHGitRunner
 from impl.MvnCommitWalker import MvnCommitWalker
 from impl.MvnVersionWalker import MvnVersionWalker, JMHMvnRunner
@@ -18,6 +18,7 @@ def parse_cmd_params():
     parser.add_argument('-t', '--type', required=True, choices=('unit', 'benchmark'), dest="type")
     parser.add_argument('-b', '--backend', choices=('versions', 'commits'), default='commits', dest='backend')
     parser.add_argument('-r', '--runner', choices=('mvn', 'gradle'), default='mvn', dest='runner')
+    parser.add_argument('--cloud', dest='cloud', default=None)
     parser.add_argument('--from', dest='start')
     parser.add_argument('--to', dest='to')
     parser.add_argument('--step', dest='step', type=int)
@@ -86,8 +87,10 @@ with open(args.outfile, "w") as file:
     custom_args = ret['custom_args']
 
     config = backend.config
-
-    callback = FileDumper(file, args, config)
+    if args.cloud:
+        callback = CloudDumper(args.cloud)
+    else:
+        callback = FileDumper(file, args, config)
     versions = backend.generate_version_list(start=args.start, end=args.to, step=args.step, **custom_args)
     print "### We will be looking at %s distinct commits. ###" % len(versions)
     print versions


### PR DESCRIPTION
Add commandline-parameter --cloud <google project-id> which enables continuous writing of results to a google cloud storage bucket.